### PR TITLE
add INSTALL_FLAGS to Makefile for customization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+INSTALL_FLAGS=
+
 all :
 	@echo done nothing
 
@@ -5,19 +7,19 @@ cabal-diff-test-colour :
 	cabal v2-run cabal-diff:cabal-diff colour 2.3.4 2.3.5
 
 install-cabal-env :
-	cabal v2-install cabal-env --overwrite-policy=always
+	cabal v2-install cabal-env --overwrite-policy=always $(INSTALL_FLAGS)
 
 install-cabal-diff :
-	cabal v2-install cabal-diff --overwrite-policy=always
+	cabal v2-install cabal-diff --overwrite-policy=always $(INSTALL_FLAGS)
 
 install-cabal-deps :
-	cabal v2-install cabal-deps --overwrite-policy=always
+	cabal v2-install cabal-deps --overwrite-policy=always $(INSTALL_FLAGS)
 
 install-cabal-bundler :
-	cabal v2-install cabal-bundler --overwrite-policy=always
+	cabal v2-install cabal-bundler --overwrite-policy=always $(INSTALL_FLAGS)
 
 install-cabal-store-check :
-	cabal v2-install cabal-store-check --overwrite-policy=always
+	cabal v2-install cabal-store-check --overwrite-policy=always $(INSTALL_FLAGS)
 
 install-cabal-store-gc :
-	cabal v2-install cabal-store-gc --overwrite-policy=always
+	cabal v2-install cabal-store-gc --overwrite-policy=always $(INSTALL_FLAGS)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ To install individual executables from this repository,
 2. Clone it with `git clone https://github.com/phadej/cabal-extras.git`
 3. Install individual executables with `make install-cabal-env`, `make install-cabal-deps` etc.
 
+You can pass flags to `cabal install` by setting `INSTALL_FLAGS`, e.g.
+
+```
+make INSTALL_FLAGS="--installdir $HOME/bin --install-method copy" install-cabal-env
+```
+
 # Executables
 
 ## cabal-bundler


### PR DESCRIPTION
I found it useful to change the installation directory on demand instead of changing it cabal.conf. Therefore I added the INSTALL_FLAGS parameter. Maybe someone else find it useful, too.

This PR is a friendly suggestion feel free to reject.