### PR TITLE
Simple properties

### DIFF
--- a/cabal-docspec/MANUAL.md
+++ b/cabal-docspec/MANUAL.md
@@ -83,6 +83,10 @@ However, in this list we mostly only list and show the --option version of them.
 :   Message to return when the evaluation is timed out.
     Default is **\* Hangs forever \***.
 
+**\--ghci-rtsopts** *options*
+
+:   RTS options for GHCi process
+
 **\--skip-properties**
 
 :   Skip properties.
@@ -178,6 +182,8 @@ There are some examples using explanatory comments,
 Some examples are illustrating non-termination,
 therefore short **\--timeout** is justified.
 Yet, it have to be long enough so terminating examples have time to run.
+We also set RTS options, reducing the maximum stack to
+make stack overflow exceptions occur earlier.
 Few examples are using symbols from *mtl*, *deepseq* and *bytestring* packages,
 we make them available.
 Finally, some modules are documented with no-Prelude assumption,
@@ -188,7 +194,8 @@ therefore we have to turn it off.
         -I $PWD/includes \
         --no-cabal-plan \
         --strip-comments \
-        --timeout 2.5 \
+        --timeout 2 \
+        --ghci-rtsopts "-K500K" \
         --extra-package=mtl --extra-package=deepseq --extra-package=bytestring \
         -XNoImplicitPrelude \
         libraries/base/base.cabal

--- a/cabal-docspec/MANUAL.md
+++ b/cabal-docspec/MANUAL.md
@@ -98,7 +98,7 @@ However, in this list we mostly only list and show the --option version of them.
 
 **\--property-variables** *varlist*
 
-:   Variables to automatically quantify over in properties.
+:   Variables to quantify over in properties.
 
 **\-X** *extension*
 
@@ -181,10 +181,10 @@ There are some examples using explanatory comments,
 **\--strip-comments** makes them work.
 Some examples are illustrating non-termination,
 therefore short **\--timeout** is justified.
-Yet, it have to be long enough so terminating examples have time to run.
+Yet, it has to be long enough so the terminating examples have time to run.
 We also set RTS options, reducing the maximum stack to
 make stack overflow exceptions occur earlier.
-Few examples are using symbols from *mtl*, *deepseq* and *bytestring* packages,
+Since the examples below use symbols from the *mtl*, *deepseq* and *bytestring* packages,
 we make them available.
 Finally, some modules are documented with no-Prelude assumption,
 therefore we have to turn it off.
@@ -425,12 +425,12 @@ QuickCheck properties
 
 Haddock (since version 2.13.0) has markup support for properties
 cabal-docspec can verify properties with QuickCheck.
-Note: there are some differences with Doctest.
+Note: this works somewhat differently than it does in Doctest.
 
 By default properties are skipped. This is a **\--skip-properties** behaviour.
 cabal-docspec has a simple mechanism to evaluate properties
 enabled by **\--simple-properties**.
-For it to work *QuickCheck* package have to be in the install plan.
+For it to work, the *QuickCheck* package has to be in the install plan.
 
 A simple property looks like this:
 
@@ -439,8 +439,8 @@ A simple property looks like this:
 -- prop> \xs -> sort xs == (sort . sort) (xs :: [Int])
 ```
 
-The lambda abstraction is not optional by default.
-cabal-docspec will automatically qualify over variables
+The lambda abstraction is required by default.
+cabal-docspec will quantify over variables
 passed in with **\--property-variables** command line flag.
 
 With **--property-variables xs** the following will work:
@@ -450,10 +450,10 @@ With **--property-variables xs** the following will work:
 -- prop> sort xs == (sort . sort) (xs :: [Int])
 ```
 
-Doctest uses a hack to find which variables are free in the the expression,
-cabal-docspec approach is more deterministic, it doesn't try to infer anything.
+Doctest uses a hack to find which variables are free in the the expression.
+cabal-docspec's approach is more deterministic, as it doesn't try to infer anything.
 
-Also contrary to *Doctest* cabal-docspec doesn't use **polyQuickCheck** trick.
+Also, in contrast to *Doctest*, cabal-docspec doesn't use the **polyQuickCheck** trick.
 Therefore some false properties may pass
 
 ```haskell
@@ -461,15 +461,15 @@ quickCheck $ \xs -> reverse xs === xs
 +++ OK, passed 100 tests.
 ```
 
-That property passes because list element types defaults to **()**.
-To avoid defaulting you may override defaults class resoltuion in **$setup** block
+That property passes because the list element type defaults to **()**.
+To avoid defaulting you may override the default class resolution in a **$setup** block
 
 ```haskell
 -- $setup
 -- >>> default (Integer, Double)
 ```
 
-Then the above property will fail:
+Then the property above will fail:
 
 ```haskell
 quickCheck $ \xs -> reverse xs === xs

--- a/cabal-docspec/MANUAL.md
+++ b/cabal-docspec/MANUAL.md
@@ -638,7 +638,7 @@ For example even
 is enough.
 However, without libraries actually being built, cabal-docspec won't work.
 
-Q: Does Doctest's --fast have an equivalent in cabal-docspec?
+Q: Does Doctest's \--fast have an equivalent in cabal-docspec?
 -------------------------------------------------------------
 
 No, cabal-doctest doesn't need one.

--- a/cabal-docspec/MANUAL.md
+++ b/cabal-docspec/MANUAL.md
@@ -83,10 +83,27 @@ However, in this list we mostly only list and show the --option version of them.
 :   Message to return when the evaluation is timed out.
     Default is **\* Hangs forever \***.
 
+**\--skip-properties**
+
+:   Skip properties.
+
+**\--simple-properties**
+
+:   Evaluate **prop> expr x y** using **quickCheck (expr x y)**.
+    Requires *QuickCheck* package in the plan.
+
+**\--property-variables** *varlist*
+
+:   Variables to automatically quantify over in properties.
+
 **\-X** *extension*
 
 :   Language extension to start GHCi session with.
     Can be specified multiple times.
+
+**\-I** *directory*
+
+:   Add *directory* to the directory search list for **#include** files.
 
 **\--phase1**
 
@@ -139,6 +156,10 @@ through fields in a .cabal file.
 
 :    A (space separated) list of extra packages. See **\--extra-package**.
 
+**x-docspec-property-variables:** *[VAR]*...
+
+:    A (space separated) list of property variables. See **\--property-variables**.
+
 EXAMPLES
 ========
 
@@ -156,16 +177,19 @@ There are some examples using explanatory comments,
 **\--strip-comments** makes them work.
 Some examples are illustrating non-termination,
 therefore short **\--timeout** is justified.
-Few examples are using symbols from *mtl* and *deepseq* packages,
+Yet, it have to be long enough so terminating examples have time to run.
+Few examples are using symbols from *mtl*, *deepseq* and *bytestring* packages,
 we make them available.
 Finally, some modules are documented with no-Prelude assumption,
 therefore we have to turn it off.
 
-    cabal-docspec -w $PWD/_build/stage1/bin/ghc \
+    cabal-docspec \
+        -w $PWD/_build/stage1/bin/ghc \
+        -I $PWD/includes \
         --no-cabal-plan \
         --strip-comments \
-        --timeout 2 \
-        --extra-package=mtl --extra-package=deepseq \
+        --timeout 2.5 \
+        --extra-package=mtl --extra-package=deepseq --extra-package=bytestring \
         -XNoImplicitPrelude \
         libraries/base/base.cabal
 
@@ -392,10 +416,15 @@ If a line contains three dots and additional content, the three dots will match 
 QuickCheck properties
 ---------------------
 
-**NOTE:** cabal-docspec doesn't check properties at the moment. Details may change.
-
 Haddock (since version 2.13.0) has markup support for properties
-Doctest can verify properties with QuickCheck.
+cabal-docspec can verify properties with QuickCheck.
+Note: there are some differences with Doctest.
+
+By default properties are skipped. This is a **\--skip-properties** behaviour.
+cabal-docspec has a simple mechanism to evaluate properties
+enabled by **\--simple-properties**.
+For it to work *QuickCheck* package have to be in the install plan.
+
 A simple property looks like this:
 
 ```haskell
@@ -403,11 +432,43 @@ A simple property looks like this:
 -- prop> \xs -> sort xs == (sort . sort) (xs :: [Int])
 ```
 
-The lambda abstraction is optional and can be omitted:
+The lambda abstraction is not optional by default.
+cabal-docspec will automatically qualify over variables
+passed in with **\--property-variables** command line flag.
+
+With **--property-variables xs** the following will work:
 
 ```haskell
 -- |
 -- prop> sort xs == (sort . sort) (xs :: [Int])
+```
+
+Doctest uses a hack to find which variables are free in the the expression,
+cabal-docspec approach is more deterministic, it doesn't try to infer anything.
+
+Also contrary to *Doctest* cabal-docspec doesn't use **polyQuickCheck** trick.
+Therefore some false properties may pass
+
+```haskell
+quickCheck $ \xs -> reverse xs === xs
++++ OK, passed 100 tests.
+```
+
+That property passes because list element types defaults to **()**.
+To avoid defaulting you may override defaults class resoltuion in **$setup** block
+
+```haskell
+-- $setup
+-- >>> default (Integer, Double)
+```
+
+Then the above property will fail:
+
+```haskell
+quickCheck $ \xs -> reverse xs === xs
+*** Failed! Falsified (after 4 tests and 4 shrinks):    
+[1,0]
+[0,1] /= [1,0]
 ```
 
 A complete example that uses setup code is below:
@@ -430,21 +491,6 @@ fib :: Int -> Int
 fib 0 = 0
 fib 1 = 1
 fib n = fib (n - 1) + fib (n - 2)
-```
-
-If you see an error like the following, ensure that *QuickCheck* is a dependency of the test-suite or executable running docspec (to be corrected).
-
-```haskell
-<interactive>:39:3:
-    Not in scope: ‘polyQuickCheck’
-    In the splice: $(polyQuickCheck (mkName "doctest_prop"))
-
-<interactive>:39:3:
-    GHC stage restriction:
-      ‘polyQuickCheck’ is used in a top-level splice or annotation,
-      and must be imported, not defined locally
-    In the expression: polyQuickCheck (mkName "doctest_prop")
-    In the splice: $(polyQuickCheck (mkName "doctest_prop"))
 ```
 
 Hiding examples from Haddock
@@ -520,6 +566,10 @@ All warnings are enabled by default.
 **-Werror-in-setup**
 
 :   There was an error in evaluting **$setup**.
+
+**-Wskipped-property**
+
+:   Warn about properties when **\--skip-properties** (the default) is enabled.
 
 KNOWN BUGS AND INFECILITIES
 ===========================

--- a/cabal-docspec/Makefile
+++ b/cabal-docspec/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.0.0.20210110
+VERSION=0.0.0.20210111
 
 cabal-docspec.1 : MANUAL.md
 	echo '.TH CABAL-DOCSPEC 1 "January 10, 2021" "cabal-docspec $(VERSION)" "Cabal Extras"' > cabal-docspec.1

--- a/cabal-docspec/cabal-docspec.1
+++ b/cabal-docspec/cabal-docspec.1
@@ -99,7 +99,7 @@ Evaluate \f[B]prop> expr x y\f[R] using \f[B]quickCheck (expr x y)\f[R].
 Requires \f[I]QuickCheck\f[R] package in the plan.
 .TP
 \f[B]--property-variables\f[R] \f[I]varlist\f[R]
-Variables to automatically quantify over in properties.
+Variables to quantify over in properties.
 .TP
 \f[B]-X\f[R] \f[I]extension\f[R]
 Language extension to start GHCi session with.
@@ -172,11 +172,13 @@ There are some examples using explanatory comments,
 \f[B]--strip-comments\f[R] makes them work.
 Some examples are illustrating non-termination, therefore short
 \f[B]--timeout\f[R] is justified.
-Yet, it have to be long enough so terminating examples have time to run.
+Yet, it has to be long enough so the terminating examples have time to
+run.
 We also set RTS options, reducing the maximum stack to make stack
 overflow exceptions occur earlier.
-Few examples are using symbols from \f[I]mtl\f[R], \f[I]deepseq\f[R] and
-\f[I]bytestring\f[R] packages, we make them available.
+Since the examples below use symbols from the \f[I]mtl\f[R],
+\f[I]deepseq\f[R] and \f[I]bytestring\f[R] packages, we make them
+available.
 Finally, some modules are documented with no-Prelude assumption,
 therefore we have to turn it off.
 .IP
@@ -463,13 +465,14 @@ will match anything \f[I]within that line\f[R]:
 .PP
 Haddock (since version 2.13.0) has markup support for properties
 cabal-docspec can verify properties with QuickCheck.
-Note: there are some differences with Doctest.
+Note: this works somewhat differently than it does in Doctest.
 .PP
 By default properties are skipped.
 This is a \f[B]--skip-properties\f[R] behaviour.
 cabal-docspec has a simple mechanism to evaluate properties enabled by
 \f[B]--simple-properties\f[R].
-For it work \f[I]QuickCheck\f[R] package have to be in the install plan.
+For it to work, the \f[I]QuickCheck\f[R] package has to be in the
+install plan.
 .PP
 A simple property looks like this:
 .IP
@@ -480,11 +483,11 @@ A simple property looks like this:
 \f[R]
 .fi
 .PP
-The lambda abstraction is not optional by default.
-cabal-docspec will automatically qualify over variables passed in with
+The lambda abstraction is required by default.
+cabal-docspec will quantify over variables passed in with
 \f[B]--property-variables\f[R] command line flag.
 .PP
-With \f[B]\[en]property-variables xs\f[R] the following will work.
+With \f[B]\[en]property-variables xs\f[R] the following will work:
 .IP
 .nf
 \f[C]
@@ -493,13 +496,13 @@ With \f[B]\[en]property-variables xs\f[R] the following will work.
 \f[R]
 .fi
 .PP
-We chose to require explicit list of varaibles in cabal-docspec to avoid
-surprises triggered by implicit behaviour.
 Doctest uses a hack to find which variables are free in the the
-expression, cabal-docspec approach is more deterministic.
+expression.
+cabal-docspec\[cq]s approach is more deterministic, as it doesn\[cq]t
+try to infer anything.
 .PP
-Also contrary to \f[I]Doctest\f[R] cabal-docspec doesn\[cq]t use
-\f[B]polyQuickCheck\f[R] trick.
+Also, in contrast to \f[I]Doctest\f[R], cabal-docspec doesn\[cq]t use
+the \f[B]polyQuickCheck\f[R] trick.
 Therefore some false properties may pass
 .IP
 .nf
@@ -509,7 +512,9 @@ quickCheck $ \[rs]xs -> reverse xs === xs
 \f[R]
 .fi
 .PP
-To avoid defaulting to (), you may override defaults class resoltuion in
+That property passes because the list element type defaults to
+\f[B]()\f[R].
+To avoid defaulting you may override the default class resolution in a
 \f[B]$setup\f[R] block
 .IP
 .nf
@@ -519,7 +524,7 @@ To avoid defaulting to (), you may override defaults class resoltuion in
 \f[R]
 .fi
 .PP
-Then the above property will fail, as expected:
+Then the property above will fail:
 .IP
 .nf
 \f[C]

--- a/cabal-docspec/cabal-docspec.1
+++ b/cabal-docspec/cabal-docspec.1
@@ -689,7 +689,7 @@ cabal build --dry-run
 is enough.
 However, without libraries actually being built, cabal-docspec won\[cq]t
 work.
-.SS Q: Does Doctest\[cq]s \[en]fast have an equivalent in cabal-docspec?
+.SS Q: Does Doctest\[cq]s --fast have an equivalent in cabal-docspec?
 .PP
 No, cabal-doctest doesn\[cq]t need one.
 The library code is loaded as pre-compiled object code, not interpreted

--- a/cabal-docspec/cabal-docspec.1
+++ b/cabal-docspec/cabal-docspec.1
@@ -88,9 +88,23 @@ On the other hand, too short timeout may cause false negatives.
 Message to return when the evaluation is timed out.
 Default is \f[B]* Hangs forever *\f[R].
 .TP
+\f[B]--skip-properties\f[R]
+Skip properties.
+.TP
+\f[B]--simple-properties\f[R]
+Evaluate \f[B]prop> expr x y\f[R] using \f[B]quickCheck (expr x y)\f[R].
+Requires \f[I]QuickCheck\f[R] package in the plan.
+.TP
+\f[B]--property-variables\f[R] \f[I]varlist\f[R]
+Variables to automatically quantify over in properties.
+.TP
 \f[B]-X\f[R] \f[I]extension\f[R]
 Language extension to start GHCi session with.
 Can be specified multiple times.
+.TP
+\f[B]-I\f[R] \f[I]directory\f[R]
+Add \f[I]directory\f[R] to the directory search list for
+\f[B]#include\f[R] files.
 .TP
 \f[B]--phase1\f[R]
 Stop after the first phase.
@@ -151,18 +165,21 @@ There are some examples using explanatory comments,
 \f[B]--strip-comments\f[R] makes them work.
 Some examples are illustrating non-termination, therefore short
 \f[B]--timeout\f[R] is justified.
-Few examples are using symbols from \f[I]mtl\f[R] and \f[I]deepseq\f[R]
-packages, we make them available.
+Yet, it have to be long enough so terminating examples have time to run.
+Few examples are using symbols from \f[I]mtl\f[R], \f[I]deepseq\f[R] and
+\f[I]bytestring\f[R] packages, we make them available.
 Finally, some modules are documented with no-Prelude assumption,
 therefore we have to turn it off.
 .IP
 .nf
 \f[C]
-cabal-docspec -w $PWD/_build/stage1/bin/ghc \[rs]
+cabal-docspec \[rs]
+    -w $PWD/_build/stage1/bin/ghc \[rs]
+    -I $PWD/includes \[rs]
     --no-cabal-plan \[rs]
     --strip-comments \[rs]
-    --timeout 2 \[rs]
-    --extra-package=mtl --extra-package=deepseq \[rs]
+    --timeout 2.5 \[rs]
+    --extra-package=mtl --extra-package=deepseq --extra-package=bytestring \[rs]
     -XNoImplicitPrelude \[rs]
     libraries/base/base.cabal
 \f[R]
@@ -434,12 +451,16 @@ will match anything \f[I]within that line\f[R]:
 .fi
 .SS QuickCheck properties
 .PP
-\f[B]NOTE:\f[R] cabal-docspec doesn\[cq]t check properties at the
-moment.
-Details may change.
+Haddock (since version 2.13.0) has markup support for properties
+cabal-docspec can verify properties with QuickCheck.
+Note: there are some differences with Doctest.
 .PP
-Haddock (since version 2.13.0) has markup support for properties Doctest
-can verify properties with QuickCheck.
+By default properties are skipped.
+This is a \f[B]--skip-properties\f[R] behaviour.
+cabal-docspec has a simple mechanism to evaluate properties enabled by
+\f[B]--simple-properties\f[R].
+For it work \f[I]QuickCheck\f[R] package have to be in the install plan.
+.PP
 A simple property looks like this:
 .IP
 .nf
@@ -449,12 +470,53 @@ A simple property looks like this:
 \f[R]
 .fi
 .PP
-The lambda abstraction is optional and can be omitted:
+The lambda abstraction is not optional by default.
+cabal-docspec will automatically qualify over variables passed in with
+\f[B]--property-variables\f[R] command line flag.
+.PP
+With \f[B]\[en]property-variables xs\f[R] the following will work.
 .IP
 .nf
 \f[C]
 -- |
 -- prop> sort xs == (sort . sort) (xs :: [Int])
+\f[R]
+.fi
+.PP
+We chose to require explicit list of varaibles in cabal-docspec to avoid
+surprises triggered by implicit behaviour.
+Doctest uses a hack to find which variables are free in the the
+expression, cabal-docspec approach is more deterministic.
+.PP
+Also contrary to \f[I]Doctest\f[R] cabal-docspec doesn\[cq]t use
+\f[B]polyQuickCheck\f[R] trick.
+Therefore some false properties may pass
+.IP
+.nf
+\f[C]
+quickCheck $ \[rs]xs -> reverse xs === xs
++++ OK, passed 100 tests.
+\f[R]
+.fi
+.PP
+To avoid defaulting to (), you may override defaults class resoltuion in
+\f[B]$setup\f[R] block
+.IP
+.nf
+\f[C]
+-- $setup
+-- >>> default (Integer, Double)
+\f[R]
+.fi
+.PP
+Then the above property will fail, as expected:
+.IP
+.nf
+\f[C]
+quickCheck $ \[rs]xs -> reverse xs === xs
+*** Failed! Falsified (after 4 tests and 4 shrinks):    
+[1,0]
+[0,1] /= [1,0]
 \f[R]
 .fi
 .PP
@@ -479,25 +541,6 @@ fib :: Int -> Int
 fib 0 = 0
 fib 1 = 1
 fib n = fib (n - 1) + fib (n - 2)
-\f[R]
-.fi
-.PP
-If you see an error like the following, ensure that \f[I]QuickCheck\f[R]
-is a dependency of the test-suite or executable running docspec (to be
-corrected).
-.IP
-.nf
-\f[C]
-<interactive>:39:3:
-    Not in scope: \[oq]polyQuickCheck\[cq]
-    In the splice: $(polyQuickCheck (mkName \[dq]doctest_prop\[dq]))
-
-<interactive>:39:3:
-    GHC stage restriction:
-      \[oq]polyQuickCheck\[cq] is used in a top-level splice or annotation,
-      and must be imported, not defined locally
-    In the expression: polyQuickCheck (mkName \[dq]doctest_prop\[dq])
-    In the splice: $(polyQuickCheck (mkName \[dq]doctest_prop\[dq]))
 \f[R]
 .fi
 .SS Hiding examples from Haddock
@@ -572,6 +615,10 @@ C preprocessor (\f[I]cpphs\f[R]) warnings.
 .TP
 \f[B]-Werror-in-setup\f[R]
 There was an error in evaluting \f[B]$setup\f[R].
+.TP
+\f[B]-Wskipped-property\f[R]
+Warn about properties when \f[B]--skip-properties\f[R] (the default) is
+enabled.
 .SH KNOWN BUGS AND INFECILITIES
 .PP
 Properties (\f[B]prop>\f[R]) are recognized but not evaluated.

--- a/cabal-docspec/cabal-docspec.1
+++ b/cabal-docspec/cabal-docspec.1
@@ -1,4 +1,4 @@
-.TH CABAL-DOCSPEC 1 "January 10, 2021" "cabal-docspec 0.0.0.20210110" "Cabal Extras"
+.TH CABAL-DOCSPEC 1 "January 10, 2021" "cabal-docspec 0.0.0.20210111" "Cabal Extras"
 .SH NAME
 .PP
 cabal-docspec - another doctest for Haskell
@@ -88,6 +88,9 @@ On the other hand, too short timeout may cause false negatives.
 Message to return when the evaluation is timed out.
 Default is \f[B]* Hangs forever *\f[R].
 .TP
+\f[B]--ghci-rtsopts\f[R] \f[I]options\f[R]
+RTS options for GHCi process
+.TP
 \f[B]--skip-properties\f[R]
 Skip properties.
 .TP
@@ -145,6 +148,10 @@ allow configuration of cabal-docspec per component under test.
 \f[B]x-docspec-extra-packages:\f[R] \f[I][PKG]\f[R]\&...
 A (space separated) list of extra packages.
 See \f[B]--extra-package\f[R].
+.TP
+\f[B]x-docspec-property-variables:\f[R] \f[I][VAR]\f[R]\&...
+A (space separated) list of property variables.
+See \f[B]--property-variables\f[R].
 .SH EXAMPLES
 .PP
 A simplest example, which should work for most packages is to run
@@ -166,6 +173,8 @@ There are some examples using explanatory comments,
 Some examples are illustrating non-termination, therefore short
 \f[B]--timeout\f[R] is justified.
 Yet, it have to be long enough so terminating examples have time to run.
+We also set RTS options, reducing the maximum stack to make stack
+overflow exceptions occur earlier.
 Few examples are using symbols from \f[I]mtl\f[R], \f[I]deepseq\f[R] and
 \f[I]bytestring\f[R] packages, we make them available.
 Finally, some modules are documented with no-Prelude assumption,
@@ -178,7 +187,8 @@ cabal-docspec \[rs]
     -I $PWD/includes \[rs]
     --no-cabal-plan \[rs]
     --strip-comments \[rs]
-    --timeout 2.5 \[rs]
+    --timeout 2 \[rs]
+    --ghci-rtsopts \[dq]-K500K\[dq] \[rs]
     --extra-package=mtl --extra-package=deepseq --extra-package=bytestring \[rs]
     -XNoImplicitPrelude \[rs]
     libraries/base/base.cabal

--- a/cabal-docspec/cabal-docspec.cabal
+++ b/cabal-docspec/cabal-docspec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cabal-docspec
-version:            0.0.0.20210110
+version:            0.0.0.20210111
 synopsis:           Run examples in your docs
 category:           Development
 description:

--- a/cabal-docspec/cabal-docspec.cabal
+++ b/cabal-docspec/cabal-docspec.cabal
@@ -8,13 +8,17 @@ description:
   rely on @ghc@ library.
 
 license:            GPL-2.0-or-later
-license-files:      LICENSE LICENSE.GPLv2 LICENSE.GPLv3
+license-files:
+  LICENSE
+  LICENSE.GPLv2
+  LICENSE.GPLv3
+
 author:             Oleg Grenrus <oleg.grenrus@iki.fi>
 maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
 tested-with:        GHC ==8.6.5 || ==8.8.4 || ==8.10.2
 extra-source-files:
-  Changelog.md
   cabal-docspec.1
+  Changelog.md
 
 source-repository head
   type:     git
@@ -25,7 +29,7 @@ library internal-cpphs
   default-language: Haskell2010
   hs-source-dirs:   cpphs
   build-depends:
-    , base         >=4.12   && <5
+    , base         >=4.12    && <5
     , directory    ^>=1.3.0.2
     , polyparse    ^>=1.13
     , time-compat  ^>=1.9.4
@@ -59,6 +63,7 @@ library cabal-docspec-internal
     CabalDocspec.Doctest.Example
     CabalDocspec.Doctest.Extract
     CabalDocspec.Doctest.Parse
+    CabalDocspec.ExprVars
     CabalDocspec.GHCi
     CabalDocspec.Lexer
     CabalDocspec.Located
@@ -118,7 +123,20 @@ executable cabal-docspec
   default-language: Haskell2010
   hs-source-dirs:   cli
   main-is:          Main.hs
-  ghc-options:      -Wall -threaded
+  ghc-options:      -Wall -rtsopts -threaded
   build-depends:
     , base
     , cabal-docspec-internal
+
+test-suite cabal-docspec-tests
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   tests
+  main-is:          tests.hs
+  ghc-options:      -Wall -rtsopts -threaded
+  build-depends:
+    , base
+    , cabal-docspec-internal
+    , containers
+    , tasty
+    , tasty-hunit

--- a/cabal-docspec/src/CabalDocspec/ExprVars.hs
+++ b/cabal-docspec/src/CabalDocspec/ExprVars.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DeriveFunctor #-}
+module CabalDocspec.ExprVars (
+    exprVars,
+) where
+
+import Peura
+
+import qualified Language.Haskell.Lexer  as L
+import qualified Data.Set as Set
+
+exprVars :: String -> Set String
+exprVars input =
+    expr Set.empty Set.empty $ filter notWhitespace $ L.lexerPass0 input
+  where
+    expr :: Set String -> Set String -> [L.PosToken] -> Set String
+    expr  acc  bound []                                 = Set.difference acc bound
+    
+    -- collect ids
+    expr  acc  bound ((L.Varid, (_, v))         : rest) = expr (Set.insert v acc) bound rest
+    -- we skip Varsyms. Don't use them in properties :)
+
+    expr  acc  bound ((L.Reservedop, (_, "\\")) : rest) = 
+        let (vars, rest') = span notArrow rest
+        in expr acc (bound <> Set.fromList (mapMaybe isVarid vars)) rest'
+
+    -- debug
+    -- expr  acc  bound rest = error (show (take 5 rest))
+
+    -- for other tokens, we simply continue.
+    expr  acc  bound (_                         : rest) = expr acc bound rest
+
+notWhitespace :: L.PosToken -> Bool
+notWhitespace (L.Whitespace, _) = False
+notWhitespace _                 = True
+
+isVarid :: L.PosToken -> Maybe String
+isVarid (L.Varid, (_, v)) = Just v
+isVarid _                 = Nothing
+
+notArrow :: L.PosToken -> Bool
+notArrow (L.Reservedop, (_, "->")) = False
+notArrow _                         = True

--- a/cabal-docspec/src/CabalDocspec/Phase1.hs
+++ b/cabal-docspec/src/CabalDocspec/Phase1.hs
@@ -23,12 +23,13 @@ phase1
     :: TracerPeu r Tr
     -> GhcInfo
     -> Path Absolute       -- ^ package directory
+    -> [Path Absolute]     -- ^ additional include directories
     -> [PackageIdentifier] -- ^ dependencies
     -> C.BuildInfo
     -> C.ModuleName
     -> Path Absolute
     -> Peu r (Module (Located String))
-phase1 tracer ghcInfo pkgDir pkgIds bi modname modpath = do
+phase1 tracer ghcInfo pkgDir cppDirs pkgIds bi modname modpath = do
     traceApp tracer $ TracePhase1 modname modpath
 
     contents <- fromUTF8BS <$> readByteString modpath
@@ -52,7 +53,7 @@ phase1 tracer ghcInfo pkgDir pkgIds bi modname modpath = do
         -- so may break
         [ pkgDir </> fromUnrootedFilePath dir
         | dir <- C.includeDirs bi
-        ]
+        ] ++ cppDirs
 
     cppDefines :: [(String, String)]
     cppDefines =

--- a/cabal-docspec/src/CabalDocspec/Phase2.hs
+++ b/cabal-docspec/src/CabalDocspec/Phase2.hs
@@ -56,6 +56,11 @@ phase2 tracer dynOpts unitIds ghcInfo mbuildDir cabalCfg cwd extraEnv parsed = d
 
     let GhcFlags {..} = getGhcFlags ghcInfo
 
+    let rtsArgs :: [String]
+        rtsArgs
+            | null (optGhciRtsopts dynOpts) = []
+            | otherwise = ["+RTS"] ++ optGhciRtsopts dynOpts ++ ["-RTS"]
+
     let ghciArgs :: [String]
         ghciArgs =
             [ "-i" -- so we don't explode on hs-source-dirs: . packages
@@ -76,7 +81,7 @@ phase2 tracer dynOpts unitIds ghcInfo mbuildDir cabalCfg cwd extraEnv parsed = d
             ] ++
             [ ghcFlagPackageId ++ "=" ++ u
             | u <- map prettyShow unitIds
-            ]
+            ] ++ rtsArgs
 
     currEnv <- liftIO getEnvironment
     let env = Map.toList $ Map.fromList $ extraEnv ++ currEnv

--- a/cabal-docspec/src/CabalDocspec/Warning.hs
+++ b/cabal-docspec/src/CabalDocspec/Warning.hs
@@ -10,6 +10,7 @@ data W
     | WInvalidField
     | WCpphs
     | WErrorInSetup
+    | WSkippedProperty
   deriving (Eq, Ord, Enum, Bounded)
 
 instance Universe W where universe = [minBound .. maxBound]
@@ -23,3 +24,4 @@ instance Warning W where
     warningToFlag WInvalidField        = "invalid-field"
     warningToFlag WCpphs               = "cpphs"
     warningToFlag WErrorInSetup        = "error-in-setup"
+    warningToFlag WSkippedProperty     = "skipped-property"

--- a/cabal-docspec/tests/tests.hs
+++ b/cabal-docspec/tests/tests.hs
@@ -1,0 +1,22 @@
+module Main (main) where
+
+import Test.Tasty (defaultMain, testGroup, TestTree)
+import Test.Tasty.HUnit (testCase, (@=?))
+
+import qualified Data.Set as Set
+
+import CabalDocspec.ExprVars
+
+main :: IO ()
+main = defaultMain $ testGroup "cabal-docspec"
+    [ exprVarsTests
+    ]
+
+exprVarsTests :: TestTree
+exprVarsTests = testGroup "ExprVars"
+    [ ex "x + y"                                 ["x","y"]
+    , ex "forAll xs $ \\x -> x == x"             ["forAll", "xs"]
+    , ex "\\(xs :: [Int]) -> reverse xs === xs"  ["reverse"]
+    ]
+  where
+    ex expr vars = testCase expr $ Set.fromList vars @=? exprVars expr


### PR DESCRIPTION
cc @RyanGlScott, I would appreciate your comments on this approach. It makes `cabal-doscpec` test properties for `intervals` with very small diff to https://github.com/ekmett/intervals/pull/65

```diff
--- a/intervals.cabal
+++ b/intervals.cabal
@@ -72,7 +72,8 @@ library
     ghc-options: -fplugin=Herbie
 
   default-language: Haskell2010
-  x-docspec-extra-packages: QuickCheck
+  x-docspec-options: --simple-properties
+  x-docspec-property-variables: i x y xs ys
```

The `QuickCheck` dependency is implied by `--simple-properties`. The meaning of `x-docspec-property-variables:` is explained in the manual.