### PR TITLE
Generate more complete OpenBSD port Makefile fragment

### DIFF
--- a/cabal-bundler/fixtures/openbsd-ports.txt
+++ b/cabal-bundler/fixtures/openbsd-ports.txt
@@ -1,7 +1,9 @@
+MODCABAL_STEM		= cabal-fmt
+MODCABAL_VERSION	= 0.1.1
+MODCABAL_MANIFEST	= \
 	Cabal	3.0.0.0	0	\
 	ansi-terminal	0.10.1	0	\
 	ansi-wl-pprint	0.6.9	2	\
-	cabal-fmt	0.1.1	0	\
 	colour	2.3.5	0	\
 	optparse-applicative	0.15.1.0	1	\
 	transformers-compat	0.6.5	0	\


### PR DESCRIPTION
  * Include the main package settings in addition to the dependencies.
  * Reliably exclude the main package from the manifest due to special
    handling in ports.