### PR TITLE
Allow paths as environment file names

### DIFF
--- a/peura/src/Peura/GHC.hs
+++ b/peura/src/Peura/GHC.hs
@@ -39,6 +39,7 @@ import Peura.Tracer
 
 data GhcInfo = GhcInfo
     { ghcPath     :: FilePath
+    , ghcPlatform :: String
     , ghcVersion  :: Version
     , ghcEnvDir   :: Path Absolute
     , ghcGlobalDb :: Path Absolute
@@ -84,6 +85,7 @@ getGhcInfo tracer ghc = do
 
             return GhcInfo
                 { ghcPath     = ghc
+                , ghcPlatform = x ++ "-" ++ y
                 , ghcVersion  = ver
                 , ghcEnvDir   = ghcDir </> fromUnrootedFilePath (x ++ "-" ++ y ++ "-" ++ prettyShow ver) </> fromUnrootedFilePath "environments"
                 , ghcGlobalDb = globalDb


### PR DESCRIPTION
Mirroring the behaviour of ghc and cabal install --lib

"foo" -> $ghcEnvDir/foo
"./" -> $pwd/.ghc.environment.$ghcPlarform-$ghcVersion
"./foo" where foo is not a directory -> $pwd/foo

Closes #17