### PR TITLE
Specify --global-package-db when calling ghc-pkg recache and check

### DIFF
--- a/cabal-store-check/src/CabalStoreCheck/Main.hs
+++ b/cabal-store-check/src/CabalStoreCheck/Main.hs
@@ -195,6 +195,7 @@ checkConsistency tracer opts = do
         void $ runProcessCheck tracer storeDir ghcPkg
             [ "recache"
             , packageDbFlag
+            , "--global-package-db=" <> toFilePath (ghcGlobalDb ghcInfo)
             ]
 
         -- and run vanilla ghc-pkg check on the db
@@ -202,6 +203,7 @@ checkConsistency tracer opts = do
             [ "check"
             , packageDbFlag
             , "--simple-output"
+            , "--global-package-db=" <> toFilePath (ghcGlobalDb ghcInfo)
             ]
 
 -------------------------------------------------------------------------------

--- a/cabal-store-gc/src/CabalStoreGC/Main.hs
+++ b/cabal-store-gc/src/CabalStoreGC/Main.hs
@@ -149,6 +149,7 @@ doCollect tracer opts = do
     void $ runProcessCheck tracer storeDir ghcPkg
         [ "recache"
         , packageDbFlag
+        , "--global-package-db=" <> toFilePath (ghcGlobalDb ghcInfo)
         ]
 
     -- and run vanilla ghc-pkg check on the db
@@ -156,6 +157,7 @@ doCollect tracer opts = do
         [ "check"
         , packageDbFlag
         , "--simple-output"
+        , "--global-package-db=" <> toFilePath (ghcGlobalDb ghcInfo)
         ]
 
 flippedFoldlM :: (Foldable f, Monad m) => f a -> b -> (b -> a -> m b) -> m b

--- a/peura/src/Peura/GHC.hs
+++ b/peura/src/Peura/GHC.hs
@@ -47,7 +47,7 @@ data GhcInfo = GhcInfo
     }
   deriving Show
 
-getGhcInfo 
+getGhcInfo
     :: (MakeGhcTracer t, MakePeuTracer t, MakeProcessTracer t)
     => Tracer (Peu r) t -> FilePath -> Peu r GhcInfo
 getGhcInfo tracer ghc = do
@@ -105,7 +105,10 @@ findGhcPkg tracer ghcInfo = do
     tracer' <- makeGhcTracer tracer
     traceWith tracer' $ TraceGhcFindGhcPkg ghcInfo
 
-    let guess = toFilePath $ ghcLibDir ghcInfo </> fromUnrootedFilePath "bin/ghc-pkg"
+    let guess =
+          if ghcVersion ghcInfo < mkVersion [9, 4]
+             then toFilePath $ ghcLibDir ghcInfo </> fromUnrootedFilePath "bin/ghc-pkg"
+             else toFilePath $ ghcLibDir ghcInfo </> fromUnrootedFilePath "../bin/ghc-pkg"
 
     ghcDir   <- getAppUserDataDirectory "ghc"
     verBS <- LBS.toStrict <$> runProcessCheck tracer ghcDir guess ["--version"]
@@ -182,7 +185,7 @@ data TraceGhc
     | TraceGhcFindGhcPkg GhcInfo
     | TraceGhcFindGhcPkgResult FilePath
   deriving (Show)
- 
+
 class MakeGhcTracer t where
     makeGhcTracer :: Tracer (Peu r) t -> Peu r (Tracer (Peu r) TraceGhc)
 


### PR DESCRIPTION
Fix https://github.com/phadej/cabal-extras/issues/31.

I also reached this issue https://github.com/phadej/cabal-extras/issues/75. Adding a `--global-package-db` can fix it, hopefully.