### PR TITLE
Include `include-dirs` in build directory (for Configure generated headers)

### DIFF
--- a/cabal-docspec/Changelog.md
+++ b/cabal-docspec/Changelog.md
@@ -1,7 +1,8 @@
-# 0.0.0.202312dd
+# 0.0.0.20231219
 
 - Pass `default-language` flag to GHC
 - Fix issue with CPP defines without an explicit value (i.e. `-DFOO`, not `-DBAR=42`)
+- Include `include-dirs` in build directory (for Configure generated headers)
 
 # 0.0.0.20230406
 

--- a/cabal-docspec/src/CabalDocspec/Main.hs
+++ b/cabal-docspec/src/CabalDocspec/Main.hs
@@ -252,7 +252,7 @@ testComponent tracer0 tracerTop dynOptsCli ghcInfo buildDir cabalCfg plan env pk
     -- first phase: read modules and extract the comments
     let pkgVer = C.packageVersion (pkgGpd pkg)
     modules <- for modulePaths $ \(modname, modpath) ->
-        phase1 tracer ghcInfo pkgVer (pkgDir pkg) cppEnabled cppDirs pkgIds bi modname modpath
+        phase1 tracer ghcInfo (Just buildDir) (C.packageName (pkgGpd pkg)) pkgVer (pkgDir pkg) cppEnabled cppDirs pkgIds bi modname modpath
 
     -- extract doctests from the modules.
     let parsed :: [Module [Located DocTest]]
@@ -347,7 +347,7 @@ testComponentNo tracer0 tracerTop dynOptsCli ghcInfo cabalCfg dbG pkg = do
     -- first phase: read modules and extract the comments
     let pkgVer = C.packageVersion (pkgGpd pkg)
     modules <- for modulePaths $ \(modname, modpath) ->
-        phase1 tracer ghcInfo pkgVer (pkgDir pkg) cppEnabled cppDirs pkgIds bi modname modpath
+        phase1 tracer ghcInfo Nothing (C.packageName (pkgGpd pkg)) pkgVer (pkgDir pkg) cppEnabled cppDirs pkgIds bi modname modpath
 
     -- extract doctests from the modules.
     let parsed :: [Module [Located DocTest]]


### PR DESCRIPTION
Fixes https://github.com/phadej/cabal-extras/issues/139