### PR TITLE
Bump Haskell-lexer dependency to 1.2.1

### DIFF
--- a/cabal-docspec/cabal-docspec.cabal
+++ b/cabal-docspec/cabal-docspec.cabal
@@ -114,7 +114,7 @@ library cabal-docspec-internal
     , cabal-install-parsers  ^>=0.6
     , cabal-plan             ^>=0.7.0.0
     , Glob                   ^>=0.10.0
-    , haskell-lexer          ^>=1.1
+    , haskell-lexer          ^>=1.2.1
     , optparse-applicative   ^>=0.18.0.0
     , splitmix               ^>=0.1.0.3
     , unliftio-core          ^>=0.2.0.1

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 with-compiler: ghc-9.8.2
-index-state: 2024-07-03T13:49:27Z
+-- index-state: 2024-07-03T13:49:27Z
 tests: True
 
 packages: cabal-bundler


### PR DESCRIPTION
This commit bumps Haskell-lexer dependency to 1.2.1; which resolves issues around unicode lexing.

Effectively resolves #131 

NB. The Update to cabal.project file relaxing the `index-state` is questionable. I'm not sure what your exact policies are, but obviously haskell-lexer-1.2.1 won't be visible without an update to `index-state`. Please review.

